### PR TITLE
[#242] add boxShadowColor property to Profile

### DIFF
--- a/components/Officers.js
+++ b/components/Officers.js
@@ -22,6 +22,7 @@ const Officers = () => {
 					>
 						<Profile
 							color={Colors[index % Colors.length]}
+							boxShadowColor='shadow-acm-white'
 							name={officer.name}
 							pronouns={officer.pronoun}
 							position={officer.position}

--- a/components/Profile.js
+++ b/components/Profile.js
@@ -10,7 +10,7 @@ import {
 
 const Profile = ({
 	color,
-	boxShadowColor = "shadow-acm-black",
+	boxShadowColor,
 	name,
 	pronouns,
 	position,

--- a/components/Profile.js
+++ b/components/Profile.js
@@ -10,6 +10,7 @@ import {
 
 const Profile = ({
 	color,
+	boxShadowColor = "shadow-acm-black",
 	name,
 	pronouns,
 	position,
@@ -100,7 +101,7 @@ const Profile = ({
 			</Col>
 			<Col xs={10} className='font-lexend text-acm-black m-0 pr-0'>
 				<img
-					className={`shadow-[10px_8px_0px_0px] shadow-acm-black mb-3`}
+					className={`shadow-[10px_8px_0px_0px] ${boxShadowColor} mb-3`}
 					src={image}
 					alt='Profile Picture of Board Member'
 				/>


### PR DESCRIPTION
set board background shadow to white,

![image](https://user-images.githubusercontent.com/12877445/193470113-daf6da7a-2899-4e09-bc1b-a7892a532dfd.png)

https://github.com/acm-ucr/acm-hydra/blob/99b0432947ca566a37b462f9450945fcd6dad37e/components/Profile.js#L13 default set to black since black was used by default previously

