### PR TITLE
[#235] optimize bootstrap imports

### DIFF
--- a/components/CalendarEvents.js
+++ b/components/CalendarEvents.js
@@ -3,7 +3,8 @@ import moment from "moment";
 import { Calendar, momentLocalizer } from "react-big-calendar";
 import "react-big-calendar/lib/css/react-big-calendar.css";
 import { Events } from "./Events.js";
-import { Row, Col } from "react-bootstrap";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
 import CustomToolbar from "./CustomToolbar.js";
 import CustomEvent from "./CustomEvent.js";
 

--- a/components/Clubroom.js
+++ b/components/Clubroom.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Row, Col } from "react-bootstrap";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
 import Frame from "./Frame";
 
 const Clubroom = () => {

--- a/components/CustomToolbar.js
+++ b/components/CustomToolbar.js
@@ -1,7 +1,8 @@
 import React from "react";
 import Filter from "./Filter.js";
 import { FaArrowRight, FaArrowLeft } from "react-icons/fa";
-import { Row, Col } from "react-bootstrap";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
 import { Filters } from "./data/Filters.js";
 
 const CustomToolbar = event => {

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,5 +1,7 @@
 import React from "react";
-import { Row, Col, Container } from "react-bootstrap";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
+import Container from "react-bootstrap/Container";
 import Link from "next/link";
 import { Socials } from "./data/Socials";
 

--- a/components/Gallery.js
+++ b/components/Gallery.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Row, Col } from "react-bootstrap";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
 
 const Gallery = () => {
 	return (

--- a/components/Inspire.js
+++ b/components/Inspire.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Row, Col } from "react-bootstrap";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
 import Project from "./Project";
 import { InspireProjects } from "./InspireProjects";
 

--- a/components/Introduction.js
+++ b/components/Introduction.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Row, Col } from "react-bootstrap";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
 
 const Introduction = () => {
 	return (

--- a/components/Learn.js
+++ b/components/Learn.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Row, Col } from "react-bootstrap";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
 import Topic from "../components/Topic";
 
 const Learn = () => {

--- a/components/Navigation.js
+++ b/components/Navigation.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Nav, Navbar } from "react-bootstrap";
+import Nav from "react-bootstrap/Nav";
+import Navbar from "react-bootstrap/Navbar";
 import Link from "next/link";
 
 const Navigation = () => {

--- a/components/Officers.js
+++ b/components/Officers.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Row, Col } from "react-bootstrap";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
 import { OfficersArray } from "./data/Officers";
 import { Colors } from "./data/Colors";
 import Profile from "./Profile";

--- a/components/Profile.js
+++ b/components/Profile.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Row, Col } from "react-bootstrap";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
 import {
 	FaGithub,
 	FaLinkedin,

--- a/components/Stats.js
+++ b/components/Stats.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Row, Col } from "react-bootstrap";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
 
 const Stats = () => {
 	return (

--- a/components/StudentOrgs.js
+++ b/components/StudentOrgs.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Row, Col } from "react-bootstrap";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
 import Profile from "./Profile.js";
 
 const Orgs = [

--- a/components/Upcoming.js
+++ b/components/Upcoming.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { Row, Col } from "react-bootstrap";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
 import Event from "./Event";
 import { Events } from "./Events.js";
 

--- a/components/Vision.js
+++ b/components/Vision.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Row, Col } from "react-bootstrap";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
 import Frame from "./Frame";
 
 const Vision = () => {

--- a/components/What.js
+++ b/components/What.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Row, Col } from "react-bootstrap";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
 import Frame from "./Frame";
 
 const What = () => {

--- a/components/Why.js
+++ b/components/Why.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Row, Col } from "react-bootstrap";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
 import Frame from "./Frame";
 
 const Why = () => {


### PR DESCRIPTION
no more named imports from 'react-bootstrap' , only default imports