### PR TITLE
[#247] Footer arrangement on mobile

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -14,13 +14,12 @@ const Footer = () => {
 						Let&#39;s connect!
 					</p>
 				</Row>
-				<Row className='justify-center mx-auto w-8/12'>
+				<Row className='justify-center flex-nowrap mx-auto w-8/12'>
 					{Socials.map((link, index) => {
 						return (
 							<Col
 								key={index}
-								xs={4}
-								md={2}
+								xs='2'
 								className='flex justify-center'
 							>
 								<Link href={link.path}>
@@ -30,7 +29,11 @@ const Footer = () => {
 										title={link.title}
 										className='fill-current text-acm-white hover:text-acm-blue'
 									>
-										{link.image}
+										{(function () {
+											const x = link.image;
+											console.log(x);
+											return x;
+										})()}
 									</a>
 								</Link>
 							</Col>

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -29,11 +29,7 @@ const Footer = () => {
 										title={link.title}
 										className='fill-current text-acm-white hover:text-acm-blue'
 									>
-										{(function () {
-											const x = link.image;
-											console.log(x);
-											return x;
-										})()}
+										{link.image}
 									</a>
 								</Link>
 							</Col>

--- a/components/data/Socials.js
+++ b/components/data/Socials.js
@@ -7,36 +7,37 @@ import {
 	FaGithub,
 } from "react-icons/fa";
 
+const classNames = "text-[5vw]";
 const Socials = [
 	{
 		path: "https://www.instagram.com/acm_ucr/",
 		title: "Instagram",
-		image: <FaInstagram className='text-5xl'></FaInstagram>,
+		image: <FaInstagram className={classNames}></FaInstagram>,
 	},
 	{
 		path: "https://docs.google.com/forms/d/e/1FAIpQLSfImoSRQ7d5lQASl5OPxxEK_2iiZT0UKxVsMsn3BMVCkqC-WQ/viewform",
 		title: " Discord",
-		image: <FaDiscord className='text-5xl'></FaDiscord>,
+		image: <FaDiscord className={classNames}></FaDiscord>,
 	},
 	{
 		path: "https://www.youtube.com/channel/UCSLoGcSzNfpHIzdT6QzsmnQ",
 		title: "Youtube",
-		image: <FaYoutube className='text-5xl'></FaYoutube>,
+		image: <FaYoutube className={classNames}></FaYoutube>,
 	},
 	{
 		path: "https://github.com/acm-ucr",
 		title: "Github",
-		image: <FaGithub className='text-5xl'></FaGithub>,
+		image: <FaGithub className={classNames}></FaGithub>,
 	},
 	{
 		path: "https://join.slack.com/t/csatucr/shared_invite/zt-6fz8g1lu-oKHsfL1qx3wZMJ9k3j2sXw",
 		title: "Slack",
-		image: <FaSlack className='text-5xl'></FaSlack>,
+		image: <FaSlack className={classNames}></FaSlack>,
 	},
 	{
 		path: "https://medium.com/acm-at-ucr",
 		title: "Medium",
-		image: <FaMediumM className='text-5xl'></FaMediumM>,
+		image: <FaMediumM className={classNames}></FaMediumM>,
 	},
 ];
 

--- a/components/data/Socials.js
+++ b/components/data/Socials.js
@@ -7,37 +7,36 @@ import {
 	FaGithub,
 } from "react-icons/fa";
 
-const classNames = "text-[5vw]";
 const Socials = [
 	{
 		path: "https://www.instagram.com/acm_ucr/",
 		title: "Instagram",
-		image: <FaInstagram className={classNames}></FaInstagram>,
+		image: <FaInstagram className='text-5xl'></FaInstagram>,
 	},
 	{
 		path: "https://docs.google.com/forms/d/e/1FAIpQLSfImoSRQ7d5lQASl5OPxxEK_2iiZT0UKxVsMsn3BMVCkqC-WQ/viewform",
 		title: " Discord",
-		image: <FaDiscord className={classNames}></FaDiscord>,
+		image: <FaDiscord className='text-5xl'></FaDiscord>,
 	},
 	{
 		path: "https://www.youtube.com/channel/UCSLoGcSzNfpHIzdT6QzsmnQ",
 		title: "Youtube",
-		image: <FaYoutube className={classNames}></FaYoutube>,
+		image: <FaYoutube className='text-5xl'></FaYoutube>,
 	},
 	{
 		path: "https://github.com/acm-ucr",
 		title: "Github",
-		image: <FaGithub className={classNames}></FaGithub>,
+		image: <FaGithub className='text-5xl'></FaGithub>,
 	},
 	{
 		path: "https://join.slack.com/t/csatucr/shared_invite/zt-6fz8g1lu-oKHsfL1qx3wZMJ9k3j2sXw",
 		title: "Slack",
-		image: <FaSlack className={classNames}></FaSlack>,
+		image: <FaSlack className='text-5xl'></FaSlack>,
 	},
 	{
 		path: "https://medium.com/acm-at-ucr",
 		title: "Medium",
-		image: <FaMediumM className={classNames}></FaMediumM>,
+		image: <FaMediumM className='text-5xl'></FaMediumM>,
 	},
 ];
 


### PR DESCRIPTION
New footer behavior, use `text-5vw` instead of `text-5xl`

![image](https://user-images.githubusercontent.com/12877445/193738286-c48e55d4-1a74-4fa6-9e5b-9feb8069986b.png)
![image](https://user-images.githubusercontent.com/12877445/193738308-ae7a645d-61e4-430c-b0bc-7b8401398895.png)
![image](https://user-images.githubusercontent.com/12877445/193738332-deb30101-135d-4333-aead-996beedd60a4.png)
![image](https://user-images.githubusercontent.com/12877445/193738382-599e85b3-5fa1-4e63-81e3-76d25782c06e.png)

this should be fine since i don't think this is too big, maybe can use min() to cap size? (tailwind doesnt really support min though so this might have to be done through setting a style)