### PR TITLE
remove unnecessary className=''

### DIFF
--- a/components/Clubroom.js
+++ b/components/Clubroom.js
@@ -19,11 +19,11 @@ const Clubroom = () => {
 					</p>
 					Here are the perks:
 					<>
-						<li className=''>Whiteboard walls</li>
-						<li className=''>Programming books</li>
-						<li className=''>Lockers</li>
-						<li className=''>Snacks</li>
-						<li className=''>Drinks</li>
+						<li>Whiteboard walls</li>
+						<li>Programming books</li>
+						<li>Lockers</li>
+						<li>Snacks</li>
+						<li>Drinks</li>
 					</>
 				</Col>
 				<Col


### PR DESCRIPTION
used regex `className=('|")[^A-Za-z!]` to check all files in components, i only found these five