### PR TITLE
Spaced out social icons on mobile

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -19,7 +19,7 @@ const Footer = () => {
 						return (
 							<Col
 								key={index}
-								xs='2'
+								xs='3'
 								className='flex justify-center'
 							>
 								<Link href={link.path}>


### PR DESCRIPTION
Before:
<img width="632" alt="Screenshot 2022-12-24 at 1 05 00 AM" src="https://user-images.githubusercontent.com/92554377/209429049-65e6cd32-47e7-47d3-88bd-d57f8ad35e0d.png">

After:
<img width="649" alt="Screenshot 2022-12-24 at 1 06 33 AM" src="https://user-images.githubusercontent.com/92554377/209429057-8c50678b-e229-4f80-ace4-4aa9848c2672.png">
